### PR TITLE
Add support for multiline comments in PHP.

### DIFF
--- a/languages/patterns/php.js
+++ b/languages/patterns/php.js
@@ -1,5 +1,6 @@
 module.exports = {
   name: 'PHP',
   nameMatchers: ['.php', '.php3', '.php4', '.php5', '.fbp'],
+  multiLineComment: require('./common/c-style.js').multiLine(),
   singleLineComment: require('./common/c-style.js').singleLine()
 }

--- a/spec/javascript-spec.js
+++ b/spec/javascript-spec.js
@@ -55,6 +55,10 @@ describe('comment-patterns', function () {
       {
         name: 'PHP',
         nameMatchers: ['.php', '.php3', '.php4', '.php5', '.fbp'],
+        multiLineComment: [
+          { apidoc: true, end: '*/', middle: '*', start: /\/\*\*/ },
+          { end: '*/', middle: '*', start: /\/\*/ }
+        ],
         singleLineComment: [ { start: '//' } ]
       }
     )


### PR DESCRIPTION
PHP supports and developers strongly encourage the use of multiline comments. 