### PR TITLE
Add '.mjs' files support and prevent posible error generating database.

### DIFF
--- a/build/generate-db.js
+++ b/build/generate-db.js
@@ -6,7 +6,11 @@ var Generator = require('./generator.js')
 // Generate base directory
 var databaseDir = path.resolve(__dirname, '..', 'db-generated')
 if (!fs.existsSync(databaseDir)) {
-  fs.mkdir(databaseDir)
+  try {
+    fs.mkdir(databaseDir)
+  } catch (Error) {
+    fs.mkdirSync(databaseDir)
+  }
 }
 
 var generator = new Generator()

--- a/languages/patterns/javascript.js
+++ b/languages/patterns/javascript.js
@@ -1,6 +1,6 @@
 module.exports = {
   name: 'JavaScript',
-  nameMatchers: ['.js'],
+  nameMatchers: ['.js', '.mjs'],
   multiLineComment: require('./common/c-style.js').multiLine(),
   singleLineComment: require('./common/c-style.js').singleLine()
 }


### PR DESCRIPTION
- Add [ES6 experimental NodeJS modules](https://nodejs.org/docs/latest/api/esm.html) including the extension `.mjs` in Javascript language.
- Prevent next error installing the library with `npm install`:
```
> comment-patterns@0.10.1 prepublish /home/mondeja/files/code/comment-patterns
> node build/generate-db.js

fs.js:160
    throw new ERR_INVALID_CALLBACK(cb);
    ^

TypeError [ERR_INVALID_CALLBACK]: Callback must be a function. Received undefined
    at makeCallback (fs.js:160:11)
    at Object.mkdir (fs.js:909:14)
    at Object.<anonymous> (/home/mondeja/files/code/comment-patterns/build/generate-db.js:9:6)
    at Module._compile (internal/modules/cjs/loader.js:1200:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:1220:10)
    at Module.load (internal/modules/cjs/loader.js:1049:32)
    at Function.Module._load (internal/modules/cjs/loader.js:937:14)
    at Function.executeUserEntryPoint [as runMain] (internal/modules/run_main.js:71:12)
    at internal/main/run_main_module.js:17:47 {
  code: 'ERR_INVALID_CALLBACK'
}
```